### PR TITLE
Keyboard should return to abc if not already there when user hits space or return

### DIFF
--- a/app/src/main/java/com/enaboapps/switchify/keyboard/SwitchifyKeyboardService.kt
+++ b/app/src/main/java/com/enaboapps/switchify/keyboard/SwitchifyKeyboardService.kt
@@ -398,6 +398,7 @@ class SwitchifyKeyboardService : InputMethodService(), KeyboardLayoutListener, P
 
             KeyType.Space -> {
                 currentInputConnection.commitText(" ", 1)
+                KeyboardLayoutManager.switchLayout(KeyboardLayoutType.AlphabeticLower)
             }
 
             KeyType.ImeAction -> {
@@ -417,6 +418,7 @@ class SwitchifyKeyboardService : InputMethodService(), KeyboardLayoutListener, P
                         KeyEvent.KEYCODE_ENTER
                     )
                 )
+                KeyboardLayoutManager.switchLayout(KeyboardLayoutType.AlphabeticLower)
             }
 
             KeyType.Tab -> {


### PR DESCRIPTION
Fixes #643

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/enaboapps/Switchify/issues/643?shareId=56d3e8f4-ae05-4477-9ba7-e7a1a4329275).