### PR TITLE
Fix app picker description to show 'Will open [app]'

### DIFF
--- a/app/src/main/java/com/enaboapps/switchify/screens/settings/switches/actions/extras/SwitchActionAppLaunchPicker.kt
+++ b/app/src/main/java/com/enaboapps/switchify/screens/settings/switches/actions/extras/SwitchActionAppLaunchPicker.kt
@@ -34,6 +34,6 @@ fun SwitchActionAppLaunchPicker(
             onAppSelected(updatedAction)
         },
         itemToString = { it.displayName },
-        itemDescription = { it.packageName }
+        itemDescription = { "Will open ${it.displayName}" }
     )
 }


### PR DESCRIPTION
Fixes #647

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/enaboapps/Switchify/issues/647?shareId=7bfa4e51-800b-4ff7-a0fb-aa8cc2dacf01).