### PR TITLE
Fix CI failing due to missing google-services.json

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,5 +28,46 @@ jobs:
         echo "fleksy.apiKey=your_api_key" >> local.properties
         echo "fleksy.apiSecret=your_api_secret" >> local.properties
 
+    - name: Create placeholder google-services.json
+      run: |
+        mkdir -p app
+        echo '{
+          "project_info": {
+            "project_number": "1234567890",
+            "project_id": "your_project_id"
+          },
+          "client": [
+            {
+              "client_info": {
+                "mobilesdk_app_id": "1:1234567890:android:abcdef123456",
+                "android_client_info": {
+                  "package_name": "com.enaboapps.switchify"
+                }
+              },
+              "oauth_client": [
+                {
+                  "client_id": "1234567890-abcdef123456.apps.googleusercontent.com",
+                  "client_type": 1,
+                  "android_info": {
+                    "package_name": "com.enaboapps.switchify",
+                    "certificate_hash": "ABCDEF1234567890ABCDEF1234567890ABCDEF12"
+                  }
+                }
+              ],
+              "api_key": [
+                {
+                  "current_key": "your_api_key"
+                }
+              ],
+              "services": {
+                "appinvite_service": {
+                  "other_platform_oauth_client": []
+                }
+              }
+            }
+          ],
+          "configuration_version": "1"
+        }' > app/google-services.json
+
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
Fixes #761

Add a step in the CI workflow to create a placeholder `google-services.json` file before the build step.

* Create a new step named "Create placeholder google-services.json" in `.github/workflows/android.yml`.
* Add minimal required content to the placeholder `google-services.json` file to ensure the build process can proceed without errors.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/enaboapps/Switchify/pull/762?shareId=a094bbb9-7a4d-46cc-9336-0037bd7cf492).