### PR TITLE
Fix CI setup to write default_web_client_id to strings.xml

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -69,5 +69,10 @@ jobs:
           "configuration_version": "1"
         }' > app/google-services.json
 
+    - name: Add default_web_client_id to strings.xml
+      run: |
+        mkdir -p app/src/main/res/values
+        echo '<resources><string name="default_web_client_id">your_default_web_client_id</string></resources>' > app/src/main/res/values/strings.xml
+
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
Fixes #763

Add a step to write `default_web_client_id` to `strings.xml` during CI setup.

* Create a new step in `.github/workflows/android.yml` to add `default_web_client_id` to `strings.xml`.
* Ensure the `strings.xml` file is created in the appropriate directory with the required content.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/enaboapps/Switchify/pull/764?shareId=b4134547-b371-44bf-a6c2-0429e54451f7).